### PR TITLE
Make babel a peer dep

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -65,7 +65,6 @@ function transformDirectorySync(inDir, outDir, options) {
         transformFileSync(fullInPath, fullOutPath, options);
       } else {
         console.log('Copying non-js file ' + fullInPath + ' to ' + fullOutPath);
-        mkdirP.sync(path.dirname(fullOutPath));
         fs.writeFileSync(fullOutPath, fs.readFileSync(fullInPath));
       }
     }

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -65,6 +65,7 @@ function transformDirectorySync(inDir, outDir, options) {
         transformFileSync(fullInPath, fullOutPath, options);
       } else {
         console.log('Copying non-js file ' + fullInPath + ' to ' + fullOutPath);
+        mkdirP.sync(path.dirname(fullOutPath));
         fs.writeFileSync(fullOutPath, fs.readFileSync(fullInPath));
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-compile",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "A script to compile .js and .jsx to es6 with Babel using babel-core, that actually works!",
   "main": "lib/compile.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,11 +21,13 @@
   "license": "MPL-2.0",
   "homepage": "https://github.com/jhford/babel-compile",
   "dependencies": {
-    "babel-core": "^5.8.25",
     "commander": "^2.8.1",
     "fs-walk": "0.0.1",
     "lodash": "^3.10.1",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.4.3"
+  },
+  "peerDependencies": {
+    "babel-core": "^5.8.25"
   }
 }


### PR DESCRIPTION
As a peer dependency, it is the responsibility of the parent project to specify compatible the babel-runtime and babel-code version...

@jhford, the alternative to this is to let the version number of this package follow the version numbers of babel-core.

At the moment the link isn't super good right now... it's easy to break when a new babel version comes out...
